### PR TITLE
Fix regex to match all packages version formats

### DIFF
--- a/library/apt-cyg
+++ b/library/apt-cyg
@@ -81,7 +81,7 @@ def main():
 
 def installed_version(module, apt_cyg_path, name):
     (rc, out, err) = module.run_command("awk '$1~pkg && $0=$2' pkg=^%s$ /etc/setup/installed.db" % (name))
-    r = re.compile(r"%s-([0-9a-zA-Z]+\.[0-9a-zA-Z]+\.[0-9a-zA-Z]+-[0-9a-zA-Z]+)" % (name))
+    r = re.compile(r"%s-([0-9-.]+)\..*" % (name))
     version = r.search(out)
     installed_version = None
     if version != None:


### PR DESCRIPTION
This fixes handling cygwin packages with shorter or longer version format. Like in tmux package.
'tmux-2.4-1.tar.xz' will be not matched by existing regex.