### PR TITLE
re.escaping package name

### DIFF
--- a/library/apt-cyg
+++ b/library/apt-cyg
@@ -81,7 +81,7 @@ def main():
 
 def installed_version(module, apt_cyg_path, name):
     (rc, out, err) = module.run_command("awk '$1~pkg && $0=$2' pkg=^%s$ /etc/setup/installed.db" % (name))
-    r = re.compile(r"%s-([0-9-.]+)\..*" % (name))
+    r = re.compile(r"%s-([0-9-.]+)\..*" % (re.escape(name)))
     version = r.search(out)
     installed_version = None
     if version != None:


### PR DESCRIPTION
Currently when you will try to install some package with `+` or any other regexp special char in the package name, like `gcc-g++` it will fail. This pull request fixes the issue.